### PR TITLE
Update Go version to 1.26.4

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Use a multi-stage build process to reduce the final image size.
-FROM --platform=$BUILDPLATFORM golang:1.24.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 WORKDIR /app
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/SGNL-ai/TraTs-Demo-Svcs/gateway
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/order/Dockerfile
+++ b/order/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Use a multi-stage build process to reduce the final image size.
-FROM --platform=$BUILDPLATFORM golang:1.24.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 WORKDIR /app
 

--- a/order/go.mod
+++ b/order/go.mod
@@ -1,6 +1,6 @@
 module github.com/SGNL-ai/TraTs-Demo-Svcs/order
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.17.0

--- a/stocks/Dockerfile
+++ b/stocks/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Use a multi-stage build process to reduce the final image size.
-FROM --platform=$BUILDPLATFORM golang:1.24.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 WORKDIR /app
 

--- a/stocks/go.mod
+++ b/stocks/go.mod
@@ -1,6 +1,6 @@
 module github.com/SGNL-ai/TraTs-Demo-Svcs/stocks
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.17.0


### PR DESCRIPTION
Bumps go directive in all three go.mod files (order, stocks, gateway) from 1.25.0 to 1.26.4, and updates the base image in all three Dockerfiles from golang:1.24.0 to golang:1.26.4.